### PR TITLE
clean up reqs, nc_py_api=0.10.0

### DIFF
--- a/lib/main.py
+++ b/lib/main.py
@@ -37,6 +37,7 @@ from apscheduler.triggers.cron.fields import BaseField
 from huggingface_hub import \
     snapshot_download  # missing in docu - https://cloud-py-api.github.io/nc_py_api/NextcloudTalkBotTransformers.html
 from nc_py_api.ex_app import (
+    AppAPIAuthMiddleware,
     run_app,
     set_handlers,
     anc_app,
@@ -62,12 +63,14 @@ logging.getLogger('apscheduler').setLevel(logging.DEBUG)
 
 # The same stuff as for usual External Applications
 @asynccontextmanager
-async def lifespan(_app: FastAPI):
-    set_handlers(APP, enabled_handler)
+async def lifespan(app: FastAPI):
+    set_handlers(app, enabled_handler)
     yield
 
 
 APP = FastAPI(lifespan=lifespan)
+APP.add_middleware(AppAPIAuthMiddleware)
+
 # We define bot globally, so if no `multiprocessing` module is used, it can be reused by calls.
 # All stuff in it works only with local variables, so in the case of multithreading, there should not be problems.
 SUMMARAI = talk_bot.TalkBot(f"/{os.environ['APP_ID']}", f"{os.environ['APP_ID'].capitalize()}",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,2 @@
-nc_py_api[app]>=0.9.0
+nc_py_api[app]>=0.10.0
 apscheduler>=3.10.4
-transformers>=4.33
-torch
-torchvision
-torchaudio


### PR DESCRIPTION
1. AI model is used from the Nextcloud AI provider, we do not need `transformers` or `PyTorch`
2. Bumped `nc_py_api` to last version, changing of `main.py` related to this will be in a separate PR

Feel free to merge :)